### PR TITLE
Point nginx-config-processor to a patched fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,18 @@
         "php"
     ],
     "license": "MIT",
-	"require": {
-	    "php": ">=5.5.0",
-	    "romanpitak/nginx-config-processor": "v0.2.1",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/tobeorla/Nginx-Config-Processor"
+        }
+    ],
+    "require": {
+	"php": ">=5.5.0",
+	"tobeorla/nginx-config-processor": "dev-patch-1",
         "tetreum/perfect-print": "dev-master",
         "tetreum/apache-vhost-processor": "dev-master"
-	},
+    },
     "require-dev": {
         "phpunit/phpunit": "4.5.*"
     },


### PR DESCRIPTION
It's been a month since the PR to romanpitak for nginx-config-processor was sent and he hasn't accepted it yet.
¿Could you please point to that PR branch meanwhile?
